### PR TITLE
Set ecs_target.propagate_tags default value to TASK_DEFINITION

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "aws_cloudwatch_event_target" "default" {
     launch_type         = "FARGATE"
     task_count          = var.task_count
     task_definition_arn = aws_ecs_task_definition.default[0].arn
+    propagate_tags      = "TASK_DEFINITION"
 
     # Specifies the platform version for the task. Specify only the numeric portion of the platform version, such as 1.1.0.
     # This structure is used only if LaunchType is FARGATE.


### PR DESCRIPTION
AWS Terraform Provider `5.0.0`  removed default value from `ecs_target.propagate_tags` in [PR#25233](https://github.com/hashicorp/terraform-provider-aws/issues/25233). I'm setting it explicitly to `TASK_DEFINITION` in this module so the task definition can continue [propagating tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target.html#propagate_tags) to the ECS tasks.
This feature will go to release `2.2.0`.

https://sonatype.atlassian.net/browse/HDS-2238