### PR TITLE
Disabled means no resources are to be created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -231,6 +231,8 @@ data "aws_iam_policy_document" "ecs_task_role_assume_policy" {
 }
 
 resource "aws_iam_role" "ecs_task_role" {
+  count = var.enabled ? 1 : 0
+
   name               = local.ecs_task_iam_name
   assume_role_policy = data.aws_iam_policy_document.ecs_task_role_assume_policy.json
 }


### PR DESCRIPTION
Do what https://github.com/sonatype/terraform-aws-ecs-scheduled-task/blob/master/variables.tf#L95 says.

That resource is fishy, I don't see it being used by the module itself (apart from output vars). But I don't have time to figure that out.