### PR TITLE
Removed unused/empty ecs_task_role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -206,33 +206,9 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
 
 locals {
   ecs_task_execution_iam_name = "${var.name}-ecs-task-execution"
-  ecs_task_iam_name           = "${var.name}-ecs-task"
   enabled_ecs_task_execution  = var.enabled && var.create_ecs_task_execution_role ? 1 : 0
 }
 
 data "aws_iam_policy" "ecs_task_execution" {
   arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-}
-
-# ECS Task Role for Fargate
-data "aws_iam_policy_document" "ecs_task_role_assume_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type = "Service"
-
-      identifiers = [
-        "ecs-tasks.amazonaws.com",
-      ]
-    }
-  }
-}
-
-resource "aws_iam_role" "ecs_task_role" {
-  count = var.enabled ? 1 : 0
-
-  name               = local.ecs_task_iam_name
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_role_assume_policy.json
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -127,13 +127,3 @@ output "ecs_task_execution_policy_document" {
   value       = join("", aws_iam_policy.ecs_task_execution.*.policy)
   description = "The policy document of the ECS Task Execution IAM Policy."
 }
-
-output "ecs_task_role_arn" {
-  value       = join("", aws_iam_role.ecs_task_role.*.arn)
-  description = "The ARN assigned by AWS to this ECS Task IAM Policy."
-}
-
-output "ecs_task_role_name" {
-  value       = join("", aws_iam_role.ecs_task_role.*.name)
-  description = "The name of the ECS Task IAM Role."
-}


### PR DESCRIPTION
This undoes many changes originally from https://github.com/sonatype/terraform-aws-ecs-scheduled-task/commit/3aa452c17bd5c24b97e394d498e07019d5f90ee2 which AFAICT are ineffective/unused: The stated intent of that commit was adding the ecs_task_role_arn variable (which we in fact use downstream for the artifact-index merger). But when externally supplying/managing the task role, there's no point in creating a role in this module which as it stands is never used by the module for the task.

The effect can be previewed in https://github.com/sonatype/terraform-iq-hds-artifact-index/pull/226