### PR TITLE
Allow to specify target input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ resource "aws_cloudwatch_event_target" "default" {
 
   target_id = var.name
   arn       = var.cluster_arn
+  input     = var.target_input
   rule      = aws_cloudwatch_event_rule.default[0].name
   role_arn  = var.create_ecs_events_role ? join("", aws_iam_role.ecs_events.*.arn) : var.ecs_events_role_arn
 

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_event_target" "default" {
 
   target_id = var.name
   arn       = var.cluster_arn
-  input     = var.target_input
+  input     = var.target_input != "" ? var.target_input : jsonencode({})
   rule      = aws_cloudwatch_event_rule.default[0].name
   role_arn  = var.create_ecs_events_role ? join("", aws_iam_role.ecs_events.*.arn) : var.ecs_events_role_arn
 

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "ecs_task_volume_name" {
   default = ""
   type = string
 }
+
+variable "target_input" {
+  default     = jsonencode({})
+  type        = string
+  description = "Valid JSON text passed to the target."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "ecs_task_volume_name" {
 }
 
 variable "target_input" {
-  default     = jsonencode({})
+  default     = ""
   type        = string
   description = "Valid JSON text passed to the target."
 }


### PR DESCRIPTION
It's annoying: Whenever one touches the scheduled task in the AWS console, e.g. to temporarily switch it off, the next TF plan will show
`- input          = jsonencode({})`
for the `aws_cloudwatch_event_target`. This is the fix for that.

Preview at https://github.com/sonatype/terraform-iq-hds-artifact-index/pull/236#issuecomment-1829955620