### PR TITLE
Update to aws provider 5.27+

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_event_rule" "default" {
 
   name        = var.name
   description = var.description
-  is_enabled  = var.is_enabled
+  state       = var.is_enabled ? "ENABLED" : "DISABLED"
 
   # All scheduled events use UTC time zone and the minimum precision for schedules is 1 minute.
   # CloudWatch Events supports Cron Expressions and Rate Expressions

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws = ">= 2.0"
+    aws = ">= 5.27"
   }
 }


### PR DESCRIPTION
Provider version 5.27 deprecated [`aws_cloudwatch_event_rule.is_enabled` ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#is_enabled), this updates the module accordingly.  Without this, the artifact-index config can't update to recent provider versions without constantly getting the deprecation warning (cf. https://github.com/sonatype/terraform-iq-hds-artifact-index/pull/275#issuecomment-2061112484).

https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5270-november-27-2023