### PR TITLE
HDS-3271 Updates aws_ecs_task_definition resource to include runtime_platform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,13 @@ resource "aws_ecs_task_definition" "default" {
     name = var.ecs_task_volume_name
   }
 
+  # The operating system and cpu architecture. Required when Amazon ECS tasks that are hosted on Fargate.
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform
+  runtime_platform {
+    operating_system_family = var.operating_system_family
+    cpu_architecture        = var.cpu_architecture
+  }
+
   # A mapping of tags to assign to the resource.
   tags = merge({ "Name" = var.name }, var.tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -137,11 +137,13 @@ variable "target_input" {
 }
 
 variable "operating_system_family" {
+  default     = "LINUX"
   type        = string
   description = "Operating system family for runtime. Valid values are LINUX, WINDOWS_SERVER_2019_FULL, WINDOWS_SERVER_2019_CORE, WINDOWS_SERVER_2022_FULL, and WINDOWS_SERVER_2022_CORE"
 }
 
 variable "cpu_architecture" {
+  default     = "X86_64"
   type        = string
   description = "CPU architecture for runtime. Valid values are X86_64 and ARM64"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -127,11 +127,21 @@ variable "ecs_task_role_arn" {
 
 variable "ecs_task_volume_name" {
   default = ""
-  type = string
+  type    = string
 }
 
 variable "target_input" {
   default     = ""
   type        = string
   description = "Valid JSON text passed to the target."
+}
+
+variable "operating_system_family" {
+  type        = string
+  description = "Operating system family for runtime. Valid values are LINUX, WINDOWS_SERVER_2019_FULL, WINDOWS_SERVER_2019_CORE, WINDOWS_SERVER_2022_FULL, and WINDOWS_SERVER_2022_CORE"
+}
+
+variable "cpu_architecture" {
+  type        = string
+  description = "CPU architecture for runtime. Valid values are X86_64 and ARM64"
 }


### PR DESCRIPTION
As requested in [HDS-3271](https://sonatype.atlassian.net/browse/HDS-3271) this PR updates the resource block that defines the "aws_ecs_task_definition" "default" to include the runtime_platform configuration block. Since currently it is using defaults values (LINUX/x86_64) for operative system family when the FARGATE compatability is defined, so what we want is to explicitly define the values to use when calling this module.

[HDS-3271]: https://sonatype.atlassian.net/browse/HDS-3271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ